### PR TITLE
Core Testnet (devin) configs added

### DIFF
--- a/configs/coins/corecoin_testnet.json
+++ b/configs/coins/corecoin_testnet.json
@@ -1,0 +1,42 @@
+{
+  "coin": {
+    "name": "Devin",
+    "shortcut": "XAB",
+    "label": "Core Testnet",
+    "alias": "core_testnet"
+  },
+  "ports": {
+    "backend_rpc": 8036,
+    "backend_message_queue": 0,
+    "backend_p2p": 38336,
+    "backend_http": 8136,
+    "blockbook_internal": 9036,
+    "blockbook_public": 9136
+  },
+  "ipc": {
+    "rpc_url_template": "ws://127.0.0.1:{{.Ports.BackendRPC}}",
+    "rpc_timeout": 25
+  },
+  "blockbook": {
+    "package_name": "blockbook-corecoin-testnet",
+    "system_user": "blockbook-corecoin",
+    "internal_binding_template": ":{{.Ports.BlockbookInternal}}",
+    "public_binding_template": ":{{.Ports.BlockbookPublic}}",
+    "explorer_url": "",
+    "additional_params": "",
+    "block_chain": {
+      "parse": true,
+      "mempool_workers": 8,
+      "mempool_sub_workers": 2,
+      "block_addresses_to_keep": 300,
+      "additional_params": {
+        "mempoolTxTimeoutHours": 48,
+        "queryBackendOnMempoolResync": false
+      }
+    }
+  },
+  "meta": {
+    "package_maintainer": "Core Support",
+    "package_maintainer_email": "support@coreblockchain.cc"
+  }
+}


### PR DESCRIPTION
In this PR, the shortcut of the coin will be displayed as XAB for testnet. To build the package with this configuration, use the following make command
`
make all-corecoin_testnet
`

If there is a running service of blockbook which you don't want to build and install again, simply you can change the configuration here: /opt/coins/blockbook/{the coin}/config/blockchaincfg.json
for changing the symbol of coin simply change the shortcut to anything you like